### PR TITLE
Don't trim redirect_path if path is just /

### DIFF
--- a/oauth2ms
+++ b/oauth2ms
@@ -112,8 +112,8 @@ def build_new_app_state(crypt):
     state = str(uuid.uuid4())
 
     redirect_path = config["redirect_path"]
-    # Remove / at the end if present
-    if redirect_path[-1] == "/":
+    # Remove / at the end if present, and path is not just /
+    if redirect_path != "/" and redirect_path[-1] == "/":
         redirect_path = redirect_path[:-1]
 
     config["redirect_uri"] = "http://" + config['redirect_host'] + ":" + config['redirect_port'] + redirect_path


### PR DESCRIPTION
The redirect_path had a trailing / trimmed, even when the path was
just /. This broke code_key detection on line 133 because the
concatenated path didn't match the parsed_auth_response key.

Some organisations prevent a user from registering their own app, and
as such specifying their own redirect URI. For organisations that have
configure Thunderbird the redirect URI is localhost on any port with a
path of /. It's possible users in this situation may want to use a
path of just /, hence this fix.

Signed-off-by: Laurence Rochfort <laurence.rochfort@gmail.com>