### PR TITLE
Fix mbsync version requirement

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,7 +16,7 @@ Additionally, it can encode the token in the [[https://docs.microsoft.com/en-us/
 Example configuration for emacs given in [[steps.org]].
 
 * Dependencies
-Requires mbsync >= 1.3.
+Requires mbsync >= 1.4.
 More information available at: https://github.com/harishkrupo/oauth2ms/issues/2#issuecomment-846464452
 
 * Installation


### PR DESCRIPTION
oauth2ms requires mbsync >= 1.4, not 1.3.

I was very confused why this wasn't working for me on Debian Bullseye until I read #2 and realized this was a typo.